### PR TITLE
Improve scrolling of non focusable elements in game report

### DIFF
--- a/src/components/ScrollableWindow.tsx
+++ b/src/components/ScrollableWindow.tsx
@@ -1,0 +1,107 @@
+import { Focusable, ModalPosition, GamepadButton, ScrollPanelGroup, gamepadDialogClasses, scrollPanelClasses, FooterLegendProps } from "@decky/ui";
+import { FC, ReactNode, useLayoutEffect, useRef, useState } from "react";
+
+export interface ScrollableWindowProps extends FooterLegendProps {
+    height: string;
+    fadeAmount?: string;
+    scrollBarWidth?: string;
+    alwaysFocus?: boolean;
+    noScrollDescription?: boolean;
+
+    onActivate?: (e: CustomEvent) => void;
+    onCancel?: (e: CustomEvent) => void;
+    children: ReactNode;
+}
+
+export const ScrollableWindow: FC<ScrollableWindowProps> = ({ height, fadeAmount, scrollBarWidth, alwaysFocus, noScrollDescription, children, actionDescriptionMap, ...focusableProps }) => {
+    const fade = fadeAmount === undefined || fadeAmount === '' ? '10px' : fadeAmount;
+    const barWidth = scrollBarWidth === undefined || scrollBarWidth === '' ? '4px' : scrollBarWidth;
+    const [isOverflowing, setIsOverflowing] = useState(false);
+    const scrollPanelRef = useRef<HTMLElement>();
+
+    useLayoutEffect(() => {
+        const { current } = scrollPanelRef;
+        const trigger = () => {
+            if (current) {
+                const hasOverflow = current.scrollHeight > current.clientHeight;
+                setIsOverflowing(hasOverflow);
+            }
+        };
+        if (current) trigger();
+    }, [children, height]);
+
+    const panel = (
+        <ScrollPanelGroup
+            //@ts-ignore
+            ref={scrollPanelRef} focusable={false} style={{ flex: 1, minHeight: 0 }}>
+            <Focusable
+                //@ts-ignore
+                focusable={alwaysFocus || isOverflowing}
+                key={'scrollable-window-focusable-element'}
+                noFocusRing={true}
+                actionDescriptionMap={Object.assign(noScrollDescription ? {} :
+                    {
+                        [GamepadButton.DIR_UP]: 'Scroll Up',
+                        [GamepadButton.DIR_DOWN]: 'Scroll Down'
+                    },
+                    actionDescriptionMap ?? {}
+                )}
+                {...focusableProps}
+            >
+                {children}
+            </Focusable>
+        </ScrollPanelGroup>
+    );
+
+    return (
+        <>
+            <style>
+                {`.modal-position-container .${gamepadDialogClasses.ModalPosition} {
+			top: 0;
+			bottom: 0;
+			padding: 0;
+		  }
+		  .modal-position-container .${scrollPanelClasses.ScrollPanel}::-webkit-scrollbar {
+			display: initial !important;
+			width: ${barWidth};
+		  }
+		  .modal-position-container .${scrollPanelClasses.ScrollPanel}::-webkit-scrollbar-thumb {
+			border: 0;
+		  }
+		  .modal-position-container .${scrollPanelClasses.ScrollPanel}.gpfocuswithin::-webkit-scrollbar-thumb {
+			background-color: currentColor;
+		  }
+          `}
+            </style>
+            <div
+                className='modal-position-container'
+                style={{
+                    position: 'relative',
+                    height: height,
+                    WebkitMask: `linear-gradient(to right , transparent, transparent calc(100% - ${barWidth}), white calc(100% - ${barWidth})), linear-gradient(to bottom, transparent, black ${fade}, black calc(100% - ${fade}), transparent 100%)`
+                }}>
+                {isOverflowing ? (
+                    <ModalPosition key={'scrollable-window-modal-position'}>
+                        {panel}
+                    </ModalPosition>
+                ) : (
+                    <div className={`${gamepadDialogClasses.ModalPosition} ${gamepadDialogClasses.WithStandardPadding} Panel`} key={'modal-position'}>
+                        {panel}
+                    </div>
+                )}
+            </div>
+        </>
+    );
+};
+
+interface ScrollableWindowAutoProps extends Omit<ScrollableWindowProps, 'height'> {
+    heightPercent?: number;
+}
+
+export const ScrollableWindowRelative: FC<ScrollableWindowAutoProps> = ({ heightPercent, ...props }) => {
+    return (
+        <div style={{ flex: 'auto' }}>
+            <ScrollableWindow height={`${heightPercent ?? 100}%`} {...props} />
+        </div>
+    );
+};

--- a/src/components/views/GameReportView.tsx
+++ b/src/components/views/GameReportView.tsx
@@ -1,12 +1,12 @@
 import React, {useEffect, useState} from 'react';
 import {PanelSection, Focusable, DialogButton, Navigation, Router} from "@decky/ui";
 import ReactMarkdown, {Components} from 'react-markdown';
-import {Scrollable, scrollableRef, ScrollArea} from "../elements/Scrollable";
 import {reportsWebsiteBaseUrl} from "../../constants";
 import type {ExternalReview, GameReport} from "../../interfaces";
 import {MdArrowBack, MdWeb} from "react-icons/md";
 import remarkGfm from "remark-gfm";
 import rehypeSanitize from "rehype-sanitize";
+import { ScrollableWindowRelative } from '../ScrollableWindow';
 
 // Type guard to distinguish ExternalReview from GameReport.
 export const isExternalReview = (report: GameReport | ExternalReview): report is ExternalReview => {
@@ -131,7 +131,6 @@ const GameReportView: React.FC<GameReportViewProps> = ({gameReport, onGoBack}) =
         })
         .filter(entry => entry !== null) as [string, string][];
 
-    const ref = scrollableRef();
 
     const openWeb = (url: string) => {
         Navigation.NavigateToExternalWeb(url);
@@ -251,8 +250,16 @@ const GameReportView: React.FC<GameReportViewProps> = ({gameReport, onGoBack}) =
             </div>
 
 
-            <Scrollable ref={ref} className="game-report">
-                <ScrollArea scrollable={ref}>
+            <Focusable
+                style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    height: '-webkit-fill-available',
+                    width: '-webkit-fill-available',
+                    position: 'absolute'
+                }}
+            >
+                <ScrollableWindowRelative>
                     <>
                         {gameReport && (
                             <div className="game-report"
@@ -401,8 +408,9 @@ const GameReportView: React.FC<GameReportViewProps> = ({gameReport, onGoBack}) =
                             </div>
                         )}
                     </>
-                </ScrollArea>
-            </Scrollable>
+                </ScrollableWindowRelative>
+                <div style={{ height: '32px'}}/>{/*  provide space for bottom banner */}
+            </Focusable>
         </>
     );
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,7 @@ export default definePlugin(() => {
         // The name shown in various decky menus
         name: "DeckyGameSettings",
         // The element displayed at the top of your plugin's menu
-        titleView: <div className={staticClasses.Title}>Deck Settings</div>,
+        titleView: <div>Deck Settings</div>,
         // Preserve the plugin's state while the QAM is closed
         alwaysRender: true,
         // The content of your plugin's menu


### PR DESCRIPTION
-Improved scrolling
-Also fixed styling on the title view

*note: the only slighlty annoying thing about this ScrollableWindow component is that it cannot automatically detect the onCancel (when back button is pressed) callback from its ancestor focusable, instead one has to be passed manually. meaning the default cancel callback set by decky (which goes back to plugin list) will not work, however you could set it to go back to your previous view if you want.